### PR TITLE
Add source spans to AST nodes

### DIFF
--- a/compiler/lib/ast.ml
+++ b/compiler/lib/ast.ml
@@ -6,7 +6,10 @@ type span = { lo : int; hi : int } [@@deriving show]
 
 let dummy_span = { lo = 0; hi = 0 }
 
-type typ = Named of string | Pointer of typ [@@deriving show]
+type typ_desc = Named of string | Pointer of typ
+and typ = { tdesc : typ_desc; span : span } [@@deriving show]
+
+let mk_typ tdesc = { tdesc; span = dummy_span }
 
 type binop =
   | Add
@@ -92,9 +95,14 @@ let mk_stmt sdesc = { sdesc; span = dummy_span }
 type modifier = Pub | Inline [@@deriving show]
 
 (* kept separate for distinction *)
-type param = { name : string; typ : typ } [@@deriving show]
+type param = { name : string; typ : typ; span : span } [@@deriving show]
 
-type field = { name : string; typ : typ; modifiers : modifier list }
+type field = {
+  name : string;
+  typ : typ;
+  modifiers : modifier list;
+  span : span;
+}
 [@@deriving show]
 
 (* TODO(ea0e): add array types *)
@@ -104,6 +112,7 @@ type func_def = {
   ret : typ option;
   body : stmt list;
   modifiers : modifier list;
+  span : span;
 }
 [@@deriving show]
 
@@ -111,6 +120,7 @@ type struct_def = {
   name : string;
   fields : field list;
   modifiers : modifier list;
+  span : span;
 }
 [@@deriving show]
 

--- a/compiler/lib/parser.ml
+++ b/compiler/lib/parser.ml
@@ -45,15 +45,31 @@ let expect st t =
             | _ -> "token")))
   else advance st
 
-(* i32 / ^^i32 *)
+(* start of the current lookahead token *)
+let cur_pos st = st.lexbuf.Lexing.lex_start_p.pos_cnum
+
+let mk lo st desc =
+  let hi = cur_pos st in
+  { desc; span = { lo; hi } }
+
+let mks lo st sdesc =
+  let hi = cur_pos st in
+  { sdesc; span = { lo; hi } }
+
+let mkt lo st tdesc =
+  let hi = cur_pos st in
+  { tdesc; span = { lo; hi } }
+
+(* i32 *)
 let rec parse_typ st =
+  let lo = cur_pos st in
   match st.tok with
   | CARET ->
       advance st;
-      Pointer (parse_typ st)
+      mkt lo st (Pointer (parse_typ st))
   | IDENT name ->
       advance st;
-      Named name
+      mkt lo st (Named name)
   | _ -> raise (ParseError "expected type")
 
 let parse_modifiers st =
@@ -78,11 +94,14 @@ let parse_fields st =
   while st.tok <> RBRACE do
     (* TODO(9ee0): parse modifiers *)
     (* let mods = parse_modifiers st in *)
+    let lo = cur_pos st in
     let name = expect_ident st in
     expect st COLON;
     let t = parse_typ st in
+    let hi = cur_pos st in
     (* Replace modifiers with modifiers = mods *)
-    fields := ({ name; typ = t; modifiers = [] } : field) :: !fields;
+    fields :=
+      ({ name; typ = t; modifiers = []; span = { lo; hi } } : field) :: !fields;
     if st.tok = COMMA then advance st;
     skip_semi st
   done;
@@ -90,6 +109,7 @@ let parse_fields st =
 
 (* struct point { x: i32, y: i32 } *)
 let parse_struct st mods =
+  let lo = cur_pos st in
   advance st;
   (* STRUCT *)
   let name = expect_ident st in
@@ -97,24 +117,27 @@ let parse_struct st mods =
   expect st LBRACE;
   let fields = parse_fields st in
   expect st RBRACE;
+  let hi = cur_pos st in
   skip_semi st;
-  Struct { name; fields; modifiers = mods }
+  Struct { name; fields; modifiers = mods; span = { lo; hi } }
 
 (* (a: i32, b: i32) *)
 let parse_params st =
   expect st LPAREN;
   let params = ref [] in
-  if st.tok <> RPAREN then begin
+  let parse_one () =
+    let lo = cur_pos st in
     let name = expect_ident st in
     expect st COLON;
     let t = parse_typ st in
-    params := [ ({ name; typ = t } : param) ];
+    let hi = cur_pos st in
+    ({ name; typ = t; span = { lo; hi } } : param)
+  in
+  if st.tok <> RPAREN then begin
+    params := [ parse_one () ];
     while st.tok = COMMA do
       advance st;
-      let name = expect_ident st in
-      expect st COLON;
-      let t = parse_typ st in
-      params := ({ name; typ = t } : param) :: !params
+      params := parse_one () :: !params
     done
   end;
   expect st RPAREN;
@@ -158,23 +181,27 @@ and parse_stmt st =
 
 (* add(a: i32, b: i32): i32 { return a + b } *)
 let parse_func st mods =
+  let lo = cur_pos st in
   let name = expect_ident st in
   let params = parse_params st in
   let ret = parse_ret_type st in
   skip_semi st;
   let body = parse_block st in
-  Func { name; params; ret; body; modifiers = mods }
+  let hi = cur_pos st in
+  Func { name; params; ret; body; modifiers = mods; span = { lo; hi } }
 
 (* extern add(a: i32, b: i32): i32 *)
 (* No modifiers needed *)
 let parse_extern st =
+  let lo = cur_pos st in
   advance st;
   (* EXTERN *)
   let name = expect_ident st in
   let params = parse_params st in
   let ret = parse_ret_type st in
+  let hi = cur_pos st in
   skip_semi st;
-  Extern { name; params; ret; body = []; modifiers = [] }
+  Extern { name; params; ret; body = []; modifiers = []; span = { lo; hi } }
 
 let parse_decl st =
   match st.tok with

--- a/compiler/lib/typechecker.ml
+++ b/compiler/lib/typechecker.ml
@@ -57,7 +57,7 @@ let lookup_struct (env : env) (name : string) : struct_info =
   | None -> raise (TypeError ("unknown struct: " ^ name))
 
 let rec ty_of_ast (env : env) (t : typ) : ty =
-  match t with
+  match t.tdesc with
   | Named "i8" -> TInt I8
   | Named "i16" -> TInt I16
   | Named "i32" -> TInt I32

--- a/compiler/test/test_ripe.ml
+++ b/compiler/test/test_ripe.ml
@@ -4,6 +4,7 @@ open Ripe.Ast
 
 let e desc = mk_expr desc
 let s sdesc = mk_stmt sdesc
+let t tdesc = mk_typ tdesc
 
 let run decls =
   match Ripe.Typechecker.typecheck decls with
@@ -12,7 +13,7 @@ let run decls =
       print_endline ("TypeError: " ^ msg)
 
 let func ?(params = []) ?(ret = None) name body =
-  Func { name; params; ret; body; modifiers = [] }
+  Func { name; params; ret; body; modifiers = []; span = dummy_span }
 
 let%expect_test "break outside loop" =
   run [ func "f" [ s Break ] ];
@@ -27,7 +28,7 @@ let%expect_test "unbound variable" =
   [%expect {| TypeError: unbound variable: x |}]
 
 let%expect_test "type mismatch in let" =
-  run [ func "f" [ s (Let ("x", Some (Named "bool"), e (Int 42))) ] ];
+  run [ func "f" [ s (Let ("x", Some (t (Named "bool")), e (Int 42))) ] ];
   [%expect {| TypeError: type mismatch: expected TBool, got (TInt I32) |}]
 
 let%expect_test "wrong number of arguments" =
@@ -39,21 +40,23 @@ let%expect_test "deref non-pointer" =
   [%expect {| TypeError: cannot dereference non-pointer type: (TInt I32) |}]
 
 let%expect_test "null assigned to non-pointer" =
-  run [ func "f" [ s (Let ("x", Some (Named "i32"), e Null)) ] ];
+  run [ func "f" [ s (Let ("x", Some (t (Named "i32")), e Null)) ] ];
   [%expect {| TypeError: type mismatch: expected (TInt I32), got TNull |}]
 
 let%expect_test "identity function" =
   run
     [
       func
-        ~params:[ { name = "a"; typ = Named "i32" } ]
-        ~ret:(Some (Named "i32")) "id"
+        ~params:[ { name = "a"; typ = t (Named "i32"); span = dummy_span } ]
+        ~ret:(Some (t (Named "i32")))
+        "id"
         [ s (Return (Some (e (Ident "a")))) ];
     ];
   [%expect {| ok |}]
 
 let%expect_test "null assigned to pointer" =
-  run [ func "f" [ s (Let ("p", Some (Pointer (Named "i32")), e Null)) ] ];
+  run
+    [ func "f" [ s (Let ("p", Some (t (Pointer (t (Named "i32")))), e Null)) ] ];
   [%expect {| ok |}]
 
 let%expect_test "break inside while" =

--- a/examples/main.rp
+++ b/examples/main.rp
@@ -3,7 +3,6 @@ struct point { x: i32, y: i32 }
 extern add(a: i32, b: i32): i32
 
 add(a: i32, b: i32): i32 {
-  return a + b
 }
 
 main() {


### PR DESCRIPTION
Split typ into typ_desc and typ wrapper that carry span. Also, add span fields to param, field, func def, struct def.