### PR TITLE
Some diagnostics fixes

### DIFF
--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -153,7 +153,9 @@ and read_string st = parse
   | '\\' 't'      { Buffer.add_char st.buf '\t'; read_string st lexbuf }
   | '\\' '\\'     { Buffer.add_char st.buf '\\'; read_string st lexbuf }
   | '\\' '"'      { Buffer.add_char st.buf '"';  read_string st lexbuf }
-  | [^ '"' '\\' '{' '}']+  { Buffer.add_string st.buf (Lexing.lexeme lexbuf); read_string st lexbuf }
+  (* FIXME allow raw newlines for now, revisit them in the future *)
+  | newline { next_line lexbuf; Buffer.add_string st.buf (Lexing.lexeme lexbuf); read_string st lexbuf }
+  | [^ '"' '\\' '{' '}' '\r' '\n']+  { Buffer.add_string st.buf (Lexing.lexeme lexbuf); read_string st lexbuf }
   (* recover so the parser sees a closed string plus an error *)
   | eof  { if Buffer.length st.buf > 0 then begin
              Queue.push (STRING_PART (Buffer.contents st.buf)) st.token_queue;

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -550,7 +550,14 @@ and parse_if st =
   let else_body =
     if st.tok = ELSE then begin
       advance st;
-      (* TODO(2247): hint elseif *)
+      if st.tok = IF then
+        raise
+          (ParseError
+             Diagnostic.(
+               error "expected block after else"
+               |> at (cur_span st)
+               |> label "found if"
+               |> help "the keyword is elseif, one word"));
       skip_semi st;
       parse_block st
     end

--- a/lib/typechecker.ml
+++ b/lib/typechecker.ml
@@ -706,8 +706,11 @@ and check_stmts (env : env) (stmts : stmt list) : env * T.tstmt list =
         if returned && not warned then
           add_warning current_env s.span "unreachable code";
         let next_env, ts = check_stmt current_env s in
-        let is_return = match s.sdesc with Return _ -> true | _ -> false in
-        (next_env, ts :: acc, returned || is_return, warned || returned))
+        (* break and continue end the block just like return does *)
+        let terminates =
+          match s.sdesc with Return _ | Break | Continue -> true | _ -> false
+        in
+        (next_env, ts :: acc, returned || terminates, warned || returned))
       (env, [], false, false) stmts
   in
   (final_env, List.rev tstmts_reversed)

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -322,6 +322,17 @@ let%expect_test "parse: if condition is not a struct literal" =
   run_src "func f(x: bool) i32 { if x { return 1 } return 0 }";
   [%expect {| ok |}]
 
+let%expect_test "parse: else if hints elseif" =
+  run_src "func f(x: bool) { if x {} else if x {} }";
+  [%expect
+    {|
+    error: expected block after else
+      at <test>:1:32
+        func f(x: bool) { if x {} else if x {} }
+                                       ^~ found if
+    help: the keyword is elseif, one word
+    |}]
+
 let%expect_test "parse: while condition is not a struct literal" =
   run_src "func f(x: bool) { while x { return } }";
   [%expect {| ok |}]

--- a/test/test_parser.ml
+++ b/test/test_parser.ml
@@ -248,6 +248,16 @@ let%expect_test "parse: multiline array literal" =
     ok
     |}]
 
+let%expect_test "parse: line tracking after multiline string" =
+  run_src "func f() {\n  let s = \"line one\nline two\"\n  @\n}";
+  [%expect
+    {|
+    error: unexpected character: @
+      at <test>:4:3
+          @
+          ^
+    |}]
+
 let%expect_test "parse: modifiers on func" =
   run_src "public inline func f() {}";
   [%expect {| ok |}]

--- a/test/test_typecheck.ml
+++ b/test/test_typecheck.ml
@@ -95,6 +95,28 @@ let%expect_test "typecheck: break inside while" =
   run_src "func f() { while true { break } }";
   [%expect {| ok |}]
 
+let%expect_test "typecheck: unreachable code after break" =
+  run_src "func f() { while true { break\n    g() } }\nfunc g() {}";
+  [%expect
+    {|
+    warning: unreachable code
+      at <test>:2:5
+            g() } }
+            ^~~
+    ok
+    |}]
+
+let%expect_test "typecheck: unreachable code after continue" =
+  run_src "func f() { while true { continue\n    g() } }\nfunc g() {}";
+  [%expect
+    {|
+    warning: unreachable code
+      at <test>:2:5
+            g() } }
+            ^~~
+    ok
+    |}]
+
 let%expect_test "typecheck: forward reference" =
   run_src {|
 func f() { g() }


### PR DESCRIPTION
- Unreachable code after break/continue
- newline tracking in string literals
- elseif hint for `else if`.