### PR TITLE
Reject out of range int literals

### DIFF
--- a/lib/error.ml
+++ b/lib/error.ml
@@ -18,6 +18,11 @@ let named span msg name = error (Printf.sprintf "%s: %s" msg name) |> at span
 let arity span ~expected ~found =
   error (Printf.sprintf "%s, found %d" expected found) |> at span
 
+let int_out_of_range span ~ty ~value =
+  error "integer literal out of range"
+  |> at span
+  |> label (Printf.sprintf "%s does not fit in %s" value ty)
+
 let unsupported span msg = error (msg ^ " is not yet supported") |> at span
 
 let internal ?span msg =

--- a/lib/typechecker.ml
+++ b/lib/typechecker.ml
@@ -272,6 +272,10 @@ and synth_desc (env : env) (e : expr) : T.texpr =
   match e.desc with
   | Int n ->
       (* Printf.printf "int %d\n" n; *)
+      if not (int_literal_fits I32 n) then
+        emit env
+          (Error.int_out_of_range e.span ~ty:(show_ty (TInt I32))
+             ~value:(string_of_int n));
       T.mk (TInt I32) (T.TInt n)
   | Float f -> T.mk (TFloat F64) (T.TFloat f)
   | Bool b ->
@@ -422,9 +426,13 @@ and check_desc (env : env) (e : expr) (want : ty) : T.texpr =
   in
   match e.desc with
   | Int n -> (
-      (* TODO(0ab1): Validate n fits within want (e.g. reject 300 into u8). Also, inferred literals still default to I32 large values overflow. *)
       match want with
-      | TInt _ -> T.mk want (T.TInt n)
+      | TInt kind ->
+          if not (int_literal_fits kind n) then
+            emit env
+              (Error.int_out_of_range e.span ~ty:(show_ty want)
+                 ~value:(string_of_int n));
+          T.mk want (T.TInt n)
       (* want is not an integer type at all e.g. let y: bool = 20 *)
       | _ ->
           emit env

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -23,6 +23,22 @@ type ty =
 let int_kinds = [ I8; I16; I32; I64; U8; U16; U32; U64; Isize; Usize ]
 let float_kinds = [ F32; F64 ]
 
+let int_kind_bounds = function
+  | I8 -> (Some (-128), Some 127)
+  | I16 -> (Some (-32768), Some 32767)
+  | I32 -> (Some (-2147483648), Some 2147483647)
+  | U8 -> (Some 0, Some 255)
+  | U16 -> (Some 0, Some 65535)
+  | U32 -> (Some 0, Some 4294967295)
+  | I64 | Isize -> (None, None)
+  | U64 | Usize -> (Some 0, None)
+
+let int_literal_fits kind n =
+  let lo, hi = int_kind_bounds kind in
+  let above_lo = match lo with Some lo -> n >= lo | None -> true in
+  let below_hi = match hi with Some hi -> n <= hi | None -> true in
+  above_lo && below_hi
+
 (* single source for builtin type names used by both parsing and printing *)
 let builtin_tys =
   List.map

--- a/test/test_typecheck.ml
+++ b/test/test_typecheck.ml
@@ -1784,3 +1784,82 @@ func g() i32 {
           return
           ^~~~~~
     |}]
+
+let%expect_test "typecheck: int literal out of range rejected" =
+  run_src {|
+func main() i32 {
+  var x: u8 = 300
+  return 0
+}
+|};
+  [%expect
+    {|
+    warning: unused variable: x
+      at <test>:3:7
+          var x: u8 = 300
+              ^
+    help: prefix with an underscore: _x
+    error: integer literal out of range
+      at <test>:3:15
+          var x: u8 = 300
+                      ^~~ 300 does not fit in u8
+    |}]
+
+let%expect_test "typecheck: negative literal into unsigned rejected" =
+  run_src {|
+func main() i32 {
+  var x: u8 = -1
+  return 0
+}
+|};
+  [%expect
+    {|
+    warning: unused variable: x
+      at <test>:3:7
+          var x: u8 = -1
+              ^
+    help: prefix with an underscore: _x
+    error: integer literal out of range
+      at <test>:3:15
+          var x: u8 = -1
+                      ^~ -1 does not fit in u8
+    |}]
+
+let%expect_test "typecheck: int literal at type bound accepted" =
+  run_src
+    {|
+func main() i32 {
+  var x: u8 = 255
+  var y: i8 = -128
+  return 0
+}
+|};
+  [%expect
+    {|
+    warning: unused variable: x
+      at <test>:3:7
+          var x: u8 = 255
+              ^
+    help: prefix with an underscore: _x
+    warning: unused variable: y
+      at <test>:4:7
+          var y: i8 = -128
+              ^
+    help: prefix with an underscore: _y
+    ok
+    |}]
+
+let%expect_test "typecheck: inferred literal overflowing i32 rejected" =
+  run_src {|
+func main() i32 {
+  var x = 3000000000
+  return x
+}
+|};
+  [%expect
+    {|
+    error: integer literal out of range
+      at <test>:3:11
+          var x = 3000000000
+                  ^~~~~~~~~~ 3000000000 does not fit in i32
+    |}]


### PR DESCRIPTION
I check integer literals against their target type so `var x: u8 = 300` now errors instead of silently wrapping. I also range check inferred literals against i32, the default, so a value that overflows i32 is caught too.