### PR TITLE
Revert the escape check on assignment

### DIFF
--- a/lib/diagnostic.ml
+++ b/lib/diagnostic.ml
@@ -292,11 +292,6 @@ let expected_type (span : Ast.span) : t = error "expected type" |> at span
 let with_found (span : Ast.span) (msg : string) (found : string) : t =
   error msg |> at span |> label ("found " ^ found)
 
-let escaping_local (span : Ast.span) (noun : string) : t =
-  error (noun ^ " of a local escapes")
-  |> at span
-  |> label "points into freed stack memory"
-
 let internal ?(span : Ast.span option) (msg : string) : t =
   let d =
     error "internal compiler error"

--- a/lib/diagnostic.mli
+++ b/lib/diagnostic.mli
@@ -53,6 +53,5 @@ val bind_void : Ast.span -> t
 val expected_expression : Ast.span -> t
 val expected_type : Ast.span -> t
 val with_found : Ast.span -> string -> string -> t
-val escaping_local : Ast.span -> string -> t
 val internal : ?span:Ast.span -> string -> t
 val ice : ?span:Ast.span -> string -> 'a

--- a/lib/escape.ml
+++ b/lib/escape.ml
@@ -32,11 +32,7 @@ let rec slice_escapes (te : T.texpr) : bool =
   | _ -> false
 
 (* The frame dies at return so slices and addresses into it dangle *)
-let escapes (te : T.texpr) : escape option =
+let return_escapes (te : T.texpr) : escape option =
   match te.T.desc with
   | T.TUnOp (Ast.AddressOf, target) when storage_is_local target -> Some Address
   | _ -> if slice_escapes te then Some Slice else None
-
-(* Anything outside the frame is still alive after the frame dies so a ref left there goes bad too *)
-let assign_escapes (dest : T.texpr) (value : T.texpr) : escape option =
-  if storage_is_local dest then None else escapes value

--- a/lib/escape.mli
+++ b/lib/escape.mli
@@ -2,5 +2,4 @@
 
 type escape = Slice | Address
 
-val escapes : Typed_ast.texpr -> escape option
-val assign_escapes : Typed_ast.texpr -> Typed_ast.texpr -> escape option
+val return_escapes : Typed_ast.texpr -> escape option

--- a/lib/typechecker.ml
+++ b/lib/typechecker.ml
@@ -681,15 +681,19 @@ and synth_return (env : env) (span : Ast.span) (init : expr option) : T.texpr =
       T.mk TNever (T.TReturn (Some (synth env e)))
   | Some e ->
       let te = check env e env.ret_ty in
-      report_escape env e.span (Escape.escapes te);
+      (match Escape.return_escapes te with
+      | Some kind ->
+          let noun =
+            match kind with
+            | Escape.Slice -> "slice of a local"
+            | Escape.Address -> "address of a local"
+          in
+          emit env
+            (Diagnostic.error (noun ^ " escapes")
+            |> Diagnostic.at e.span
+            |> Diagnostic.label "points into freed stack memory")
+      | None -> ());
       T.mk TNever (T.TReturn (Some te))
-
-and report_escape (env : env) (span : Ast.span) (kind : Escape.escape option) :
-    unit =
-  match kind with
-  | Some Escape.Slice -> emit env (Diagnostic.escaping_local span "slice")
-  | Some Escape.Address -> emit env (Diagnostic.escaping_local span "address")
-  | None -> ()
 
 and new_loop (label : Ast.loop_label option) ~(valued : bool) : loop_ctx =
   {
@@ -1277,7 +1281,6 @@ and check_assign_operands (env : env) (op : binop) (l : expr) (r : expr) :
         tr
     | _ -> check env r t
   in
-  report_escape env r.span (Escape.assign_escapes tl tr);
   (tl, tr)
 
 (* An array or struct parameter arrives as a copy so the caller never sees the write *)

--- a/test/test_typecheck.ml
+++ b/test/test_typecheck.ml
@@ -1759,61 +1759,6 @@ let%expect_test "typecheck: returning a slice from a slice call ok" =
      g(xs) }";
   [%expect {| ok |}]
 
-let%expect_test "typecheck: storing a slice of a local in a global rejected" =
-  run_src
-    "var view: []i32 = undefined; func f() { var a: [3]i32 = [1,2,3]; view = a \
-     }";
-  [%expect
-    {|
-    error: slice of a local escapes
-      at <test>:1:73
-        var view: []i32 = undefined; func f() { var a: [3]i32 = [1,2,3]; view = a }
-                                                                                ^ points into freed stack memory
-    |}]
-
-let%expect_test
-    "typecheck: writing a slice of a local through a pointer rejected" =
-  run_src "func f(out: *[]i32) { var a: [3]i32 = [1,2,3]; *out = a }";
-  [%expect
-    {|
-    error: slice of a local escapes
-      at <test>:1:55
-        func f(out: *[]i32) { var a: [3]i32 = [1,2,3]; *out = a }
-                                                              ^ points into freed stack memory
-    |}]
-
-let%expect_test "typecheck: storing the address of a local in a global rejected"
-    =
-  run_src "var p: *i32 = undefined; func f() { var x: i32 = 5; p = &x }";
-  [%expect
-    {|
-    error: address of a local escapes
-      at <test>:1:57
-        var p: *i32 = undefined; func f() { var x: i32 = 5; p = &x }
-                                                                ^~ points into freed stack memory
-    |}]
-
-let%expect_test
-    "typecheck: writing the address of a local through a pointer rejected" =
-  run_src "func f(q: **i32) { var x: i32 = 5; *q = &x }";
-  [%expect
-    {|
-    error: address of a local escapes
-      at <test>:1:41
-        func f(q: **i32) { var x: i32 = 5; *q = &x }
-                                                ^~ points into freed stack memory
-    |}]
-
-let%expect_test "typecheck: writing a sub-slice of a slice param out ok" =
-  run_src "func f(xs: []i32, out: *[]i32) { *out = xs[0..2] }";
-  [%expect {| ok |}]
-
-let%expect_test "typecheck: storing a slice of a local in a local ok" =
-  run_src
-    "func f() i32 { var a: [3]i32 = [1,2,3]; var s: []i32 = a; s = a[0..2]; \
-     return s[0] }";
-  [%expect {| ok |}]
-
 let%expect_test "typecheck: inclusive range slice ok (branch 2)" =
   run_src
     "func f() i32 { var a: [3]i32 = [1,2,3]; var s: []i32 = a[0..=2]; return \


### PR DESCRIPTION
Reverts #463. The escape system is coming out entirely so the assignment check goes first.